### PR TITLE
Add option --with-grid=DIR

### DIFF
--- a/README.setup.md
+++ b/README.setup.md
@@ -4,6 +4,8 @@
 
 All the methods listed below rely on:
 
+* Specified Grid installation (--with-grid) has to be built with the `-fPIC` flag
+  (probably set with the --enable-pic option, if available)
 * a `python3-config` or a python3 installation that
   autotools can find
 

--- a/README.setup.md
+++ b/README.setup.md
@@ -4,9 +4,6 @@
 
 All the methods listed below rely on:
 
-* a `grid-config` in your path, from a Grid that was
-  built with the `-fPIC` flag, (probably set with the
-  --enable-pic option, if available).
 * a `python3-config` or a python3 installation that
   autotools can find
 
@@ -18,7 +15,7 @@ The build follows the default procedure:
     ./bootstrap.sh
     mkdir /path/to/builddir
     cd    /path/to/builddir
-    /path/to/source/configure --prefix=/path/to/installdir
+    /path/to/source/configure --with-grid=/path/to/grid/installdir --prefix=/path/to/installdir
     make -j7
     make install
 

--- a/configure.ac
+++ b/configure.ac
@@ -33,6 +33,14 @@ AC_DEFUN([my_python_version],[3.6])
 AM_PATH_PYTHON(my_python_version)
 AX_PYTHON_DEVEL([>=']my_python_version['])
 
+AC_ARG_WITH(grid,
+    AS_HELP_STRING(
+        [--with-grid=DIR],
+        [Specify grid installation directory DIR]
+  ),
+  [GRID_HOME="$with_grid"]
+)
+
 AC_ARG_ENABLE([fake-grid],
               [AS_HELP_STRING([--enable-fake-grid],
                               [Fake grid-config. Useful if you just want
@@ -59,16 +67,18 @@ AS_IF([test "x${ac_fake_grid}" = "xyes"],
     AC_SUBST([GRID_PREFIX],[FAKEGRID])
 ],
 [
-AC_CHECK_PROG([gridconfig], [grid-config],[grid-config],[])
-AS_IF([test "x${gridconfig}" = "xgrid-config"],
-      [],
-      [AC_MSG_ERROR([cannot find grid-config])])
-AC_SUBST([GRID_CXXFLAGS],[`${gridconfig} --cxxflags`])
-AC_SUBST([GRID_LDFLAGS],[`${gridconfig} --ldflags`])
-AC_SUBST([GRID_CXX],[`${gridconfig} --cxx`])
-AC_SUBST([GRID_CXXLD],[`${gridconfig} --cxxld`])
-AC_SUBST([GRID_LIBS],  [`${gridconfig} --libs`])
-AC_SUBST([GRID_PREFIX],[`${gridconfig} --prefix`])
+AS_IF([test "x${GRID_HOME}x" = "xx"],
+    [AC_PATH_PROG(GRID_CONFIG, [grid-config], [])],
+    [AC_PATH_PROG(GRID_CONFIG, [grid-config], [], [${GRID_HOME}/bin:${PATH}])])
+AS_IF([test "x${GRID_CONFIG}x" = "xx"],
+      [AC_MSG_ERROR([cannot find grid-config])],
+      [])
+AC_SUBST([GRID_CXXFLAGS],[`${GRID_CONFIG} --cxxflags`])
+AC_SUBST([GRID_LDFLAGS],[`${GRID_CONFIG} --ldflags`])
+AC_SUBST([GRID_CXX],[`${GRID_CONFIG} --cxx`])
+AC_SUBST([GRID_CXXLD],[`${GRID_CONFIG} --cxxld`])
+AC_SUBST([GRID_LIBS],  [`${GRID_CONFIG} --libs`])
+AC_SUBST([GRID_PREFIX],[`${GRID_CONFIG} --prefix`])
 ])
 
 # Unfortunately, not all versions of Grid have --cxxld and it does


### PR DESCRIPTION
One could argue that :${PATH} should be removed in line 72.
Currently configure will also search for grid in $PATH even if --with-grid=path is specified.
Removing $PATH it would only look in the specified path. If for some reasons configure is run with --with-grid without specifying a path, it would then fail in any case.

Removing $PATH might avoid the wrong (global) Grid installation being picked when the user sets a wrong directory for --with-grid=

My opinion: Leave as is: Look for grid in specified --with-grid path first, then in $PATH.

Side note: Is make distclean deleting lib/cgpt/lib/gversions.h on purpose (in-source build)?